### PR TITLE
fixed /dev/spidev1.0

### DIFF
--- a/wiringPi/wiringPiSPI.c
+++ b/wiringPi/wiringPiSPI.c
@@ -39,7 +39,7 @@
 //	Variables as they need to be passed as pointers later on
 
 const static char       *spiDev0  = "/dev/spidev0.0" ;
-const static char       *spiDev1  = "/dev/spidev0.1" ;
+const static char       *spiDev1  = "/dev/spidev1.0" ;
 const static uint8_t     spiMode  = 0 ;
 const static uint8_t     spiBPW   = 8 ;
 const static uint16_t    spiDelay = 0 ;


### PR DESCRIPTION
On my dietpi installation 2nd spi is on "/dev/spidev1.0" instead of "/dev/spidev0.1". Spi1 (pin 19,23,21)  tested and working.