### PR TITLE
Changed to work with Orange Pi Zero Plus

### DIFF
--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1289,6 +1289,8 @@ int isH3(void)
   FILE *cpuFd ;
   char line [120] ;
   char *d;
+  return 1;//by chen
+
 	if ((cpuFd = fopen ("/proc/cpuinfo", "r")) == NULL)
 		piBoardRevOops ("Unable to open /proc/cpuinfo") ;
 	  while (fgets (line, 120, cpuFd) != NULL)
@@ -1417,7 +1419,8 @@ int piBoardRev (void)
 void piBoardId (int *model, int *rev, int *mem, int *maker, int *overVolted)
 {
   FILE *cpuFd ;
-  char line [120] ;
+//  char line [120] ;  //edit by chen
+  char *line="Revision        : 0000";
   char *c ;
 
   (void)piBoardRev () ;	// Call this first to make sure all's OK. Don't care about the result.
@@ -1425,9 +1428,9 @@ void piBoardId (int *model, int *rev, int *mem, int *maker, int *overVolted)
   if ((cpuFd = fopen ("/proc/cpuinfo", "r")) == NULL)
     piBoardRevOops ("Unable to open /proc/cpuinfo") ;
 
-  while (fgets (line, 120, cpuFd) != NULL)
-    if (strncmp (line, "Revision", 8) == 0)
-      break ;
+//  while (fgets (line, 120, cpuFd) != NULL)
+//    if (strncmp (line, "Revision", 8) == 0)
+//      break ;
 
   fclose (cpuFd) ;
 


### PR DESCRIPTION
Orange Pi Zero Plus H5 throws all sorts of errors. There is a solution here:
https://github.com/xpertsavenue/WiringOP-Zero/issues/18

But I wasn't able to make it work. I found that with a few changes to wiringPi.c it works. Changes are made by this guy:
https://forum.armbian.com/topic/8062-orange-pi-zero-plus-wiringpi-modified-version-works/

I don't have a regular Orange Pi Zero, so I can't test if it breaks anything. Hope it doesn't.